### PR TITLE
Prevent "C:\" expansion

### DIFF
--- a/modules/Multiplane/cli/multiplane/load-i18n.php
+++ b/modules/Multiplane/cli/multiplane/load-i18n.php
@@ -163,7 +163,7 @@ foreach ($fs->ls('*.js', "{$tmppath}/{$zipname}/langs") as $file) {
         }
     }
 
-    if ($fs->copy($file->getRealPath(), "{$dest}/{$code}.js")) {
+    if ($fs->copy($file->getRealPath(), "{$dest}/{$code}.js", true)) {
         CLI::writeln("Downloaded tinyMCE language file to '{$dest}/{$code}.js'", true);
     } else {
         CLI::writeln("Couldn't write tinyMCE language file.", false);

--- a/modules/Multiplane/cli/multiplane/load-i18n.php
+++ b/modules/Multiplane/cli/multiplane/load-i18n.php
@@ -163,7 +163,7 @@ foreach ($fs->ls('*.js', "{$tmppath}/{$zipname}/langs") as $file) {
         }
     }
 
-    if ($fs->copy($file->getRealPath(), "{$dest}/{$code}.js", true)) {
+    if ($fs->copy($file->getRealPath(), "{$dest}/{$code}.js", false)) {
         CLI::writeln("Downloaded tinyMCE language file to '{$dest}/{$code}.js'", true);
     } else {
         CLI::writeln("Couldn't write tinyMCE language file.", false);


### PR DESCRIPTION
This pull is related to a problem while running the following command (on Windows OS):

```bash
php ./mp multiplane/load-i18n
```

![copy](https://user-images.githubusercontent.com/9614886/100676902-24b00f00-336a-11eb-8d4f-17ba1345a113.png)

Problematic line [CpMultiplane/modules/Multiplane/cli/multiplane/load-i18n.php#L166](https://github.com/raffaelj/CpMultiplane/blob/c0f64a6cb0571798228f6ab2d0f07a4fedbdb4d5/modules/Multiplane/cli/multiplane/load-i18n.php#L166):

```php
// CpMultiplane/modules/Multiplane/cli/multiplane/load-i18n.php#L166

$fs->copy($file->getRealPath(), "{$dest}/{$code}.js")

// BEFORE EXECUTION:
// source path:      D:\htdocs\cpmp-lib-skeleton\cpdata\storage\tmp\tinymce_languages\langs\it_IT.js
// destination path: D:/htdocs/cpmp-lib-skeleton/cpdata/storage/assets/cockpit/i18n/tinymce/it_IT.js

// AFTER EXECUTION:
// source path:      D:\htdocs\cpmp-lib-skeleton\cpdata\storage\tmp\tinymce_languages\langs\it_IT.js
// destination path: false

```

Source of the problematic command: [cockpit/lib/LimeExtra/Helper/Filesystem.php#L161-L166](https://github.com/agentejo/cockpit/blob/931ca2fe1a1ce0b293f7a60152e96b157e82bb1e/lib/LimeExtra/Helper/Filesystem.php#L161-L166)

```php
// cockpit/lib/LimeExtra/Helper/Filesystem.php#L161-L166

/**
 * @param $path
 * @param $dest
 * @param bool|true $_init
 * @return bool
 */
public function copy($path, $dest, $_init = true) {

  if ($_init) {
    if (\strpos($path, ':')) $path = $this->app->path($path); // not expanded because $path exists
    if (\strpos($dest, ':')) $dest = $this->app->path($dest); // return false, because $dest path doesn't exists yet 
  }
...
```

Essentially the `$_init` parameter allows you to specify whether `D:/` is interpreted as a cockpit configuration parameter.